### PR TITLE
Surround \HCode's with \ifdefined\HCode's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+I put the \HCode command inside
+
+```
+\ifdefined\HCode
+```
+
+and
+
+```
+\fi
+```
+
+This is needed because `pdflatex` gets run on all the files, as part of the TikZ externalization procedure.

--- a/triangle.tex
+++ b/triangle.tex
@@ -16,7 +16,9 @@ Two triangles are the same if they are congruent. That is, two triangles are the
 
 In the interactive window below, points $A$, $B$ and $C$ can be moved by using the mouse. Simply click-and-drag a point to a new location. You can also move a point by moving the slider bars using the same click-and-drag technique. $xA$ controls the $x$-coordinate of $A$, and $yA$ controls the $y$-coordinate of $A$. The same is true for points $B$ and $C$. You may also move the slider bars in increments of 0.01 by slowly clicking on the slider bar. For example, clicking on the $yC$ control bar to the right of the circle indicator will increase the $y$-coordinate of point $C$, moving point $C$ up slightly. You are limited to $x$ and $y$-coordinates between -5 and 5. You will use the same interactive window for all nine parts of this exploration.
 
+\ifdefined\HCode
 \HCode{<iframe scrolling="no" src="https://tube.geogebra.org/material/iframe/id/1443391/width/800/height/503/border/888888/rc/false/ai/false/sdz/true/smb/false/stb/false/stbh/true/ld/false/sri/true/at/auto" width="800px" height="503px" style="border:0px;"> </iframe>}
+\fi
 
 Exercise 1
 


### PR DESCRIPTION
During the processing of the tex files, it is not only htlatex but also pdflatex that gets run.  So the .tex files need to compile both ways, but \HCode isn't defined with pdflatex.

The \ifdefined stanza's protect pdflatex from hitting the undefined \HCode.
